### PR TITLE
URL-escape filenames, so packages with special characters like + work.

### DIFF
--- a/s3apt.py
+++ b/s3apt.py
@@ -192,7 +192,7 @@ def rebuild_package_index(prefix):
         print(obj.key)
 
         pkginfo = get_cached_control_data(obj)
-        pkginfo = pkginfo + "\n%s\n" % ("Filename: %s" % obj.key)
+        pkginfo = pkginfo + "\n%s\n" % ("Filename: %s" % urllib.quote(obj.key))
         pkginfos.append(pkginfo)
 
     package_index_obj = s3.Object(bucket_name=config.APT_REPO_BUCKET_NAME, key=prefix + "/Packages")


### PR DESCRIPTION
We had issues with packages with + in the filename, e.g. `libpython3.6-minimal_3.6.1-1+trusty1_amd64.deb` -- S3 appears to interpret the `+` as a URL-encoded space, so the package download 404s. URL-encoding this filename gives us `Filename: ubuntu/trusty/libpython3.6-minimal_3.6.1-1%2Btrusty1_amd64.deb`, which works.